### PR TITLE
Add default values for inputs

### DIFF
--- a/renovateMe/buildtask/src/index.ts
+++ b/renovateMe/buildtask/src/index.ts
@@ -19,8 +19,8 @@ async function run(): Promise<void> {
     throw new Error(`You need to 'Allow scripts to access OAuth token' in the 'options' tab of your build system.`);
   }
 
-  const renovateOptionsVersion = taskLib.getInput("renovateOptionsVersion");
-  const renovateOptionsArgs = taskLib.getInput("renovateOptionsArgs");
+  const renovateOptionsVersion = taskLib.getInput("renovateOptionsVersion") || 'latest';
+  const renovateOptionsArgs = taskLib.getInput("renovateOptionsArgs") || '';
 
   const project: string | undefined = process.env["SYSTEM_TEAMPROJECT"];
   if (!project) {


### PR DESCRIPTION
Since the inputs are not set as required, it's valid for no value to be entered.
This comes through as `null` and causes an error to be thrown when passing `null` to renovate (Renovate thinks "null" is another repo for it to go through).