### PR TITLE
Fix Versioning

### DIFF
--- a/renovateMe/buildtask/task.json
+++ b/renovateMe/buildtask/task.json
@@ -9,7 +9,7 @@
   "version": {
     "Major": 1,
     "Minor": 0,
-    "Patch": 5
+    "Patch": 6
   },
   "instanceNameFormat": "Renovate",
   "groups": [


### PR DESCRIPTION
This fixes a Versioning incompatibility which prevents us from updating and using renovate me 1.0.6 as the task version clashes with the package version.